### PR TITLE
fix: postgres indexes naming convention

### DIFF
--- a/backend/alembic.ini
+++ b/backend/alembic.ini
@@ -8,7 +8,7 @@ script_location = alembic
 # Uncomment the line below if you want the files to be prepended with date and time
 # see https://alembic.sqlalchemy.org/en/latest/tutorial.html#editing-the-ini-file
 # for all available tokens
-# file_template = %%(year)d_%%(month).2d_%%(day).2d_%%(hour).2d%%(minute).2d-%%(rev)s_%%(slug)s
+file_template = %%(year)d_%%(month).2d_%%(day).2d_%%(hour).2d%%(minute).2d-%%(rev)s_%%(slug)s
 
 # sys.path path, will be prepended to sys.path if present.
 # defaults to the current working directory.

--- a/backend/src/database/db_engine.py
+++ b/backend/src/database/db_engine.py
@@ -7,4 +7,12 @@ engine = create_engine(
     settings.postgres_url, connect_args={"options": "-c timezone=utc"}
 )
 
-metadata = MetaData()
+POSTGRES_INDEXES_NAMING_CONVENTION = {
+    "ix": "%(column_0_label)s_idx",
+    "uq": "%(table_name)s_%(column_0_name)s_key",
+    "ck": "%(table_name)s_%(constraint_name)s_check",
+    "fk": "%(table_name)s_%(column_0_name)s_fkey",
+    "pk": "%(table_name)s_pkey",
+}
+
+metadata = MetaData(naming_convention=POSTGRES_INDEXES_NAMING_CONVENTION)

--- a/backend/src/entities/authentification/router.py
+++ b/backend/src/entities/authentification/router.py
@@ -1,6 +1,5 @@
 from fastapi import APIRouter, HTTPException, Body
 
-from . import exceptions as user_exceptions
 from . import service as auth_service
 from . import exceptions as auth_exceptions
 

--- a/backend/src/entities/users/models.py
+++ b/backend/src/entities/users/models.py
@@ -2,7 +2,16 @@ from uuid import uuid4
 from datetime import datetime
 
 from sqlalchemy.types import UUID
-from sqlalchemy import Table, Column, ForeignKey, Integer, String, DateTime, LargeBinary, ARRAY
+from sqlalchemy import (
+    Table,
+    Column,
+    ForeignKey,
+    Integer,
+    String,
+    DateTime,
+    LargeBinary,
+    ARRAY,
+)
 from src.database.db_engine import metadata
 
 


### PR DESCRIPTION
Specify to salachemy how it would need to name indexes, it will fix migration scripts.
Before
<img width="738" alt="image" src="https://github.com/Hetic-web3-g1/PROJET_FIL_ROUGE_W3_G4/assets/64561439/b64a60d0-97f6-4920-9b75-f340fd0d0aa2">
Constraint where not named, the downgrade function would not have work because `op.drop_constraint(None, 'reset_token', type_='foreignkey')` would not know wich foreign key need to be dropped

Now
<img width="738" alt="image" src="https://github.com/Hetic-web3-g1/PROJET_FIL_ROUGE_W3_G4/assets/64561439/07ec3eaa-a0b7-4e3a-ba31-2eb48b236332">
Indexes, are named both in upgrade and downgrade functions